### PR TITLE
Supporting removal of translations

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "streamhub-sdk",
-  "version": "2.23.1",
+  "version": "2.23.2",
   "main": [
     "./src/main.js"
   ],

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "name": "Benjamin Goering",
     "email": "ben@livefyre.com"
   },
-  "version": "2.23.1",
+  "version": "2.23.2",
   "dependencies": {
     "bower": "1.3.6",
     "tmp": "0.0.23",


### PR DESCRIPTION
The internal structure of translations was a single object that was merged with any new data that was added. Since we want to allow users to add/remove translations in real time (and designer), changing the internal structure to be 2 objects: `translationSet` and `appLevelTranslations`.

`translationSet`: The translations that were received from the cloud configuration service for the network/site.

`appLevelTranslations`: Translations that were either set in the instance config or in designer. These will override the `translationSet` values.

Any adding/removal of translations happens in the `appLevelTranslations` tier and is always merged on top of the `translationSet` data. The resulting `translations` object is that current set of translations that are used in the SDK and apps.