### PR TITLE
LF-23469: Use multi=true query param on stream requests

### DIFF
--- a/src/collection/clients/stream-client.js
+++ b/src/collection/clients/stream-client.js
@@ -44,18 +44,26 @@ function(LivefyreHttpClient, inherits) {
         ].join("");
 
         var request = this._request({
-            url: url
+            url: url,
+            data: {multi: true}
         }, function (err, data) {
             if (err) {
                 return callback.apply(this, arguments);
             }
-            if (data.timeout) {
-                return callback(null, { timeout: data.timeout });
+
+            if (!Array.isArray(data)) {
+                data = [data];
             }
-            if (data.status === 'error') {
-                return callback(data.msg);
-            }
-            callback(null, data.data);
+
+            data.forEach(function (datum) {
+                if (datum.timeout) {
+                    return callback(null, { timeout: datum.timeout });
+                }
+                if (datum.status === 'error') {
+                    return callback(datum.msg);
+                }
+                callback(null, datum.data);
+            });
         });
 
         return request;

--- a/tests/spec/collection/clients/stream-client.js
+++ b/tests/spec/collection/clients/stream-client.js
@@ -54,7 +54,7 @@ function ($, LivefyreStreamClient) {
             });
         });
 
-        it ("should return data when getContent is called", function () {
+        it("should return data when getContent is called", function () {
             streamClient.getContent(opts, callback);
 
             waitsFor(function() {
@@ -66,6 +66,36 @@ function ($, LivefyreStreamClient) {
                 expect(callback.mostRecentCall.args[0]).toBeNull();
                 expect(callback.mostRecentCall.args[1]).toBeDefined();
                 expect(callback.mostRecentCall.args[1]).toBe(mockData);
+            });
+        });
+
+        it('should request information with the multi=true flag for multiple results', function () {
+            streamClient = new LivefyreStreamClient();
+
+            spy = spyOn(streamClient, "_request").andCallFake(function(opts, errback) {
+                return $.ajax().success(function () {
+                    errback(null, [{"data": mockData}, {"data": mockData}]);
+                });
+            });
+
+            streamClient.getContent(opts, callback);
+            expect(streamClient._request.mostRecentCall.args[0].url).toBe("https://labs-t402.stream1.fyre.co/v3.1/collection/10669131/0/");
+            expect(streamClient._request.mostRecentCall.args[0].data).toEqual({multi: true});
+
+            waitsFor(function() {
+                return callback.callCount > 0;
+            });
+
+            runs(function() {
+                expect(callback).toHaveBeenCalled();
+                expect(callback.callCount).toBe(2);
+                expect(callback.calls[0].args[0]).toBeNull();
+                expect(callback.calls[0].args[1]).toBeDefined();
+                expect(callback.calls[0].args[1]).toBe(mockData);
+                expect(callback.calls[1].args[0]).toBeNull();
+                expect(callback.calls[1].args[1]).toBeDefined();
+                expect(callback.calls[1].args[1]).toBe(mockData);
+
             });
         });
 


### PR DESCRIPTION
Using this new feature, certain streams will send bulk updates
with more than one event per response. On quick moving streams,
this enables the "catch up" period (time to live) to be quick.

https://livefyre.atlassian.net/browse/LF-23469